### PR TITLE
TRIFFHIR-479: Added additional checks in the import that allow auto s…

### DIFF
--- a/apps/client/src/app/implementation-guide-wrapper/r4/implementation-guide.component.ts
+++ b/apps/client/src/app/implementation-guide-wrapper/r4/implementation-guide.component.ts
@@ -366,10 +366,8 @@ export class R4ImplementationGuideComponent extends BaseImplementationGuideCompo
           display: result.display
         };
 
-        let tempObj;
-
-        if(allProfilingTypes.indexOf(result.resourceType) < 0 && result.resource.meta.profile){
-          tempObj = {
+        this.implementationGuide.definition.resource.push(allProfilingTypes.indexOf(result.resourceType) < 0 && result.resource.meta.profile ?
+          {
             extension: [{
               url: Globals.extensionUrls['extension-ig-resource-file-path'],
               valueString: getDefaultImplementationGuideResourcePath(newReference)
@@ -377,10 +375,8 @@ export class R4ImplementationGuideComponent extends BaseImplementationGuideCompo
             reference: newReference,
             name: result.display,
             exampleCanonical: result.resource.meta.profile
-          };
-        }
-        else {
-          tempObj = {
+          } :
+          {
             extension: [{
               url: Globals.extensionUrls['extension-ig-resource-file-path'],
               valueString: getDefaultImplementationGuideResourcePath(newReference)
@@ -388,10 +384,8 @@ export class R4ImplementationGuideComponent extends BaseImplementationGuideCompo
             reference: newReference,
             name: result.display,
             exampleBoolean: allProfilingTypes.indexOf(result.resourceType) < 0
-          };
-        }
-
-        this.implementationGuide.definition.resource.push(tempObj);
+          }
+        );
       });
     });
   }
@@ -987,7 +981,7 @@ export class R4ImplementationGuideComponent extends BaseImplementationGuideCompo
 
   public setExampleCanonical(resource: ImplementationGuideResourceComponent, value: string) {
     delete resource.exampleBoolean;
-    resource.exampleCanonical = value;
+    resource.exampleCanonical.push(value);
   }
 
   public selectExampleCanonical(resource: ImplementationGuideResourceComponent) {
@@ -998,7 +992,7 @@ export class R4ImplementationGuideComponent extends BaseImplementationGuideCompo
 
     modalRef.result.then((result: ResourceSelection) => {
       delete resource.exampleBoolean;
-      resource.exampleCanonical = (<StructureDefinition> result.resource).url;
+      resource.exampleCanonical.push((<StructureDefinition> result.resource).url);
     });
   }
 }

--- a/apps/client/src/app/implementation-guide-wrapper/r4/implementation-guide.component.ts
+++ b/apps/client/src/app/implementation-guide-wrapper/r4/implementation-guide.component.ts
@@ -981,7 +981,7 @@ export class R4ImplementationGuideComponent extends BaseImplementationGuideCompo
 
   public setExampleCanonical(resource: ImplementationGuideResourceComponent, value: string) {
     delete resource.exampleBoolean;
-    resource.exampleCanonical.push(value);
+    resource.exampleCanonical = value;
   }
 
   public selectExampleCanonical(resource: ImplementationGuideResourceComponent) {
@@ -992,7 +992,7 @@ export class R4ImplementationGuideComponent extends BaseImplementationGuideCompo
 
     modalRef.result.then((result: ResourceSelection) => {
       delete resource.exampleBoolean;
-      resource.exampleCanonical.push((<StructureDefinition> result.resource).url);
+      resource.exampleCanonical = (<StructureDefinition> result.resource).url;
     });
   }
 }

--- a/apps/client/src/app/implementation-guide-wrapper/r4/resource-modal.component.ts
+++ b/apps/client/src/app/implementation-guide-wrapper/r4/resource-modal.component.ts
@@ -54,7 +54,7 @@ export class R4ResourceModalComponent {
         delete this.resource.exampleBoolean;
       }
 
-      this.resource.exampleCanonical.push(result.resource.url);
+      this.resource.exampleCanonical = result.resource.url;
     })
   }
 

--- a/apps/client/src/app/implementation-guide-wrapper/r4/resource-modal.component.ts
+++ b/apps/client/src/app/implementation-guide-wrapper/r4/resource-modal.component.ts
@@ -54,7 +54,7 @@ export class R4ResourceModalComponent {
         delete this.resource.exampleBoolean;
       }
 
-      this.resource.exampleCanonical = result.resource.url;
+      this.resource.exampleCanonical.push(result.resource.url);
     })
   }
 

--- a/apps/server/src/app/helper.ts
+++ b/apps/server/src/app/helper.ts
@@ -365,7 +365,7 @@ export async function addToImplementationGuide(httpService: HttpService, configS
             reference: resourceReferenceString,
             display: display
           },
-          exampleCanonical: resource.meta.profile,
+          exampleCanonical: resource.meta.profile[0],
           name: display
         } :
         {

--- a/apps/server/src/app/helper.ts
+++ b/apps/server/src/app/helper.ts
@@ -359,7 +359,16 @@ export async function addToImplementationGuide(httpService: HttpService, configS
 
       logger.verbose('Resource not already part of implementation guide, adding to IG\'s list of resources.');
 
-      r4.definition.resource.push({
+      r4.definition.resource.push(Globals.profileTypes.concat(Globals.terminologyTypes).indexOf(resource.resourceType) < 0 && resource.meta.profile ?
+        {
+          reference: {
+            reference: resourceReferenceString,
+            display: display
+          },
+          exampleCanonical: resource.meta.profile,
+          name: display
+        } :
+        {
         reference: {
           reference: resourceReferenceString,
           display: display

--- a/libs/tof-lib/src/lib/r4/fhir.ts
+++ b/libs/tof-lib/src/lib/r4/fhir.ts
@@ -14649,7 +14649,7 @@ export class ImplementationGuideResourceComponent extends BackboneElement {
   public name?: string;
   public description?: string;
   public exampleBoolean? = false;
-  public exampleCanonical?: string[];
+  public exampleCanonical?: string;
   public groupingId?: string;
 
   constructor(obj?: any) {
@@ -14668,10 +14668,7 @@ export class ImplementationGuideResourceComponent extends BackboneElement {
         this.exampleBoolean = obj.exampleBoolean;
       }
       if (obj.hasOwnProperty('exampleCanonical')) {
-        this.exampleCanonical = [];
-        for(const o of obj.exampleCanonical || []){
-          this.exampleCanonical.push(o);
-        }
+        this.exampleCanonical = obj.exampleCanonical;
 
       }
       if (obj.hasOwnProperty('groupingId')) {

--- a/libs/tof-lib/src/lib/r4/fhir.ts
+++ b/libs/tof-lib/src/lib/r4/fhir.ts
@@ -14649,7 +14649,7 @@ export class ImplementationGuideResourceComponent extends BackboneElement {
   public name?: string;
   public description?: string;
   public exampleBoolean? = false;
-  public exampleCanonical?: string;
+  public exampleCanonical?: string[];
   public groupingId?: string;
 
   constructor(obj?: any) {
@@ -14668,7 +14668,11 @@ export class ImplementationGuideResourceComponent extends BackboneElement {
         this.exampleBoolean = obj.exampleBoolean;
       }
       if (obj.hasOwnProperty('exampleCanonical')) {
-        this.exampleCanonical = obj.exampleCanonical;
+        this.exampleCanonical = [];
+        for(const o of obj.exampleCanonical || []){
+          this.exampleCanonical.push(o);
+        }
+
       }
       if (obj.hasOwnProperty('groupingId')) {
         this.groupingId = obj.groupingId;


### PR DESCRIPTION
…etting of exampleCanonical when there's a noncomformant resource being imported with a meta.profile.  Also added in corrections for the exampleCanonical field within the ImplementationGuideResourceComponent where it was listed as type string instead of string[].  Made modifications to handle initializion and use.