### PR TITLE
TRIFFHIR-602

### DIFF
--- a/apps/client/src/app/implementation-guide-wrapper/r4/implementation-guide.component.html
+++ b/apps/client/src/app/implementation-guide-wrapper/r4/implementation-guide.component.html
@@ -377,7 +377,9 @@
               <th>Reference</th>
               <th>Name</th>
               <th>Group</th>
-              <th>Example?</th>
+              <th>Description
+                <app-tooltip-icon tooltipKey="ig.definition.resource.description"></app-tooltip-icon>
+              </th>
               <th class="actions-column-1">
                 <div class="btn-group pull-right">
                   <button type="button" class="btn btn-primary" (click)="addResources()" title="Add existing resources to this implementation guide">
@@ -419,7 +421,7 @@
                 <span *ngIf="resource.exampleCanonical" title="This resource is an example of a profile">{{resource.exampleCanonical.length > 30 ? '...' : ''}}{{resource.exampleCanonical.substr(-30)}}</span>
                 -->
                 <div class="input-group">
-                  <textarea class="form-control" [(ngModel)]="resource.description"></textarea>
+                  <textarea class="form-control" [(ngModel)]="resource.description" [class.is-invalid]="isDescriptionRequired(resource)"></textarea>
                 </div>
               </td>
               <td>

--- a/apps/client/src/app/implementation-guide-wrapper/r4/implementation-guide.component.html
+++ b/apps/client/src/app/implementation-guide-wrapper/r4/implementation-guide.component.html
@@ -419,19 +419,7 @@
                 <span *ngIf="resource.exampleCanonical" title="This resource is an example of a profile">{{resource.exampleCanonical.length > 30 ? '...' : ''}}{{resource.exampleCanonical.substr(-30)}}</span>
                 -->
                 <div class="input-group">
-                  <div class="input-group-prepend">
-                    <div class="input-group-text">
-                      <input type="checkbox" [ngModel]="resource.exampleBoolean || resource.exampleCanonical" (ngModelChange)="setExampleBoolean(resource, $event)" />
-                    </div>
-                  </div>
-                  <input type="text" class="form-control" [ngModel]="resource.exampleCanonical" (ngModelChange)="setExampleCanonical(resource, $event)" />
-                  <div class="input-group-append">
-                    <div class="input-group-btn">
-                      <button type="button" class="btn btn-primary" [disabled]="!resource.exampleBoolean && !resource.exampleCanonical" (click)="selectExampleCanonical(resource)">
-                        <i class="fas fa-hand-pointer"></i>
-                      </button>
-                    </div>
-                  </div>
+                  <textarea class="form-control" [(ngModel)]="resource.description"></textarea>
                 </div>
               </td>
               <td>

--- a/apps/client/src/app/implementation-guide-wrapper/r4/implementation-guide.component.ts
+++ b/apps/client/src/app/implementation-guide-wrapper/r4/implementation-guide.component.ts
@@ -1024,6 +1024,10 @@ export class R4ImplementationGuideComponent extends BaseImplementationGuideCompo
     }
   }
 
+  public isDescriptionRequired(resource: ImplementationGuideResourceComponent) {
+    return !resource.description && ((resource.hasOwnProperty('exampleBoolean') && resource.exampleBoolean === true) || (resource.hasOwnProperty('exampleCanonical') && resource.exampleCanonical !== ''));
+  }
+
   public setExampleCanonical(resource: ImplementationGuideResourceComponent, value: string) {
     delete resource.exampleBoolean;
     resource.exampleCanonical = value;
@@ -1031,8 +1035,8 @@ export class R4ImplementationGuideComponent extends BaseImplementationGuideCompo
 
   public selectExampleCanonical(resource: ImplementationGuideResourceComponent) {
     //Can only set Structure Definitions to exampleCanonical according to FHIR R4 standard
-    const modalRef = this.modal.open(FhirReferenceModalComponent, {size: 'lg'});
-    modalRef.componentInstance.resourceType = "StructureDefinition";
+    const modalRef = this.modal.open(FhirReferenceModalComponent, { size: 'lg' });
+    modalRef.componentInstance.resourceType = 'StructureDefinition';
     modalRef.componentInstance.hideResourceType = true;
 
     modalRef.result.then((result: ResourceSelection) => {

--- a/apps/client/src/app/implementation-guide-wrapper/r4/resource-modal.component.html
+++ b/apps/client/src/app/implementation-guide-wrapper/r4/resource-modal.component.html
@@ -11,14 +11,6 @@
   <app-fhir-string [parentObject]="resource" propertyName="name" title="Name" [required]="true" tooltipPath="ImplementationGuide.definition.resource.name"></app-fhir-string>
   <span *ngIf="!resource.name">You must specify a name.</span>
 
-  <div class="form-group">
-    <label>
-      Description
-      <app-tooltip-icon tooltipKey="ig.definition.resource.description"></app-tooltip-icon>
-    </label>
-    <textarea class="form-control" [(ngModel)]="resource.description" [class.is-invalid]="isDescriptionRequired"></textarea>
-    <span  *ngIf="isDescriptionRequired">When a resource is an example, description is required.</span>
-  </div>
   <p>
     <button type="button" class="btn btn-primary" *ngIf="resource.reference && resource.reference.reference" (click)="copyDescription()">Copy description from target resource</button>
   </p>


### PR DESCRIPTION
Seems to be working.

Ticket requirements:

When editing an Implementation Guide, under the “Resources” tab:

- Remove “Example” column from table (it should only be editable in the pop-up window for editing a resource)
- Add “Description” column with a multi-line text field to the table
- Change the logic that makes the “Edit” button for a resource red so that it only checks if name or description is missing.